### PR TITLE
Changed R package module load to run for CNVReport.Rmd. 

### DIFF
--- a/pipeline/cnv_detection_pipeline.sh
+++ b/pipeline/cnv_detection_pipeline.sh
@@ -174,7 +174,8 @@ less ${ID}_pindel*multianno.vcf | grep -v "#" > ${ID}_pindel_annotated.vcf
 
 ############ CNV summary and genome-wide analysis report ###############
 module purge
-module load r/intel/3.3.2
+# 11.17.17 - PS: Changed R package to run for Rscript. This fixes GenomicRanges issue in BioCondoctor package
+module load r/intel/3.4.2
 module load pandoc/gnu/1.19.2
 cp ${RUNDIR}/CNVreport.Rmd .
 Rscript -e "rmarkdown::render('CNVreport.Rmd')" ${ID}_lumpy_annotated.vcf ${ID}_pindel_annotated.vcf ${ID}_SvABA_annotated.vcf ${ID}_insert_size_metrics.txt ${ID}_alignment_metrics.txt ${ID}_RD.txt ${ID}


### PR DESCRIPTION
This fixes the GenomicRanges issue in BioCondoctor package. 
Briefly:

In the HPC Prince environment users have encountered the following error:

'Quitting from lines 360-389 (CNVreport.Rmd)
Error in (function (cl, name, valueClass) :
assignment of an object of class “NULL” is not valid for @‘NAMES’ in an object of class “IRanges”; is(value, “characterORNULL”) is not TRUE
Calls: ... new_GRanges -> IRanges -> names names '

This is due to a versioning issue involving the 'IRanges' implementation in Bioconductor's 'GenomicRanges' and 'BiocGenerics' packages. Attempting to correct this by updating BiocGenerics results in an error where the newest version is incompatible with the version Bioconductor.  The next version of Bioconductor required a more recent version of R. Working with Tatiana, the more recent version of R now has the packages installed (rmarkdown, bioconductor) necessary.